### PR TITLE
[IMPROVEMENT] Adds log directives for link (project) specific logging in NginX

### DIFF
--- a/roles/valet-link/templates/nginx/fallback.conf.j2
+++ b/roles/valet-link/templates/nginx/fallback.conf.j2
@@ -18,6 +18,9 @@ server {
     ssl_certificate {{ certificate_server_domain_fullchain_file }};
     ssl_certificate_key {{ certificate_server_domain_key_file }};
 
+    access_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-access.log;
+    error_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-error.log;
+
     index index.php index.html index.htm;
 
     location / {

--- a/roles/valet-link/templates/nginx/magento1.conf.j2
+++ b/roles/valet-link/templates/nginx/magento1.conf.j2
@@ -30,6 +30,9 @@ server {
     ssl_certificate {{ certificate_server_domain_fullchain_file }};
     ssl_certificate_key {{ certificate_server_domain_key_file }};
 
+    access_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-access.log;
+    error_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-error.log;
+
 	location  /. {
 		deny all;
 		access_log off;

--- a/roles/valet-link/templates/nginx/magento2.conf.j2
+++ b/roles/valet-link/templates/nginx/magento2.conf.j2
@@ -30,6 +30,9 @@ server {
     ssl_certificate {{ certificate_server_domain_fullchain_file }};
     ssl_certificate_key {{ certificate_server_domain_key_file }};
 
+    access_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-access.log;
+    error_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-error.log;
+
     root $MAGE_ROOT/pub;
 
     index index.php;

--- a/roles/valet-link/templates/nginx/neos.conf.j2
+++ b/roles/valet-link/templates/nginx/neos.conf.j2
@@ -17,6 +17,9 @@ server {
     ssl_certificate {{ certificate_server_domain_fullchain_file }};
     ssl_certificate_key {{ certificate_server_domain_key_file }};
 
+    access_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-access.log;
+    error_log {{ valet_sh_prefix }}/var/log/nginx/{{ link_name }}.{{ development_tld }}-error.log;
+
     root {{ valet_current_path }}/Web;
 
     index index.php;


### PR DESCRIPTION
Previously NginX would log everything to a single set of access and
error log files, which would make is hard to evaluate the logs when looking
for errors.

The purpose of this change is to allow one set of log files for every
link that is created, which should make it a lot easier to evaluate the
logs.