### PR TITLE
Fix non interactive app config import

### DIFF
--- a/roles/valet-restore/tasks/workflows/magento2/vars.yml
+++ b/roles/valet-restore/tasks/workflows/magento2/vars.yml
@@ -17,5 +17,5 @@
 valet_restore_workflow:
   post_restore_commands:
   - "bin/magento cache:flush"
-  - "bin/magento app:config:import"
+  - "bin/magento app:config:import -n"
   - "bin/magento setup:upgrade"


### PR DESCRIPTION
configure `app:config:import` to not ask anything in non interactive valet.sh context

this prevents an error that would otherwise be thrown during `app:config:import` when the `scope` section changed.