### PR TITLE
[FIX] Fixes that the php wrapper would not support PHP 8.1 although it is now officially part of the package

### DIFF
--- a/roles/php/templates/macos/php-wrapper.j2
+++ b/roles/php/templates/macos/php-wrapper.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AVAILABLE_PHP_VERSION='5.6 7.0 7.1 7.2 7.3 7.4 8.0'
+AVAILABLE_PHP_VERSION='5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1'
 
 function get_target_version {
     VALET_SH_FILE=$1

--- a/roles/php/templates/ubuntu/php-wrapper.j2
+++ b/roles/php/templates/ubuntu/php-wrapper.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AVAILABLE_PHP_VERSION='5.6 7.0 7.1 7.2 7.3 7.4 8.0'
+AVAILABLE_PHP_VERSION='5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1'
 
 function get_target_version {
     VALET_SH_FILE=$1


### PR DESCRIPTION
**Repro:**

1. Create a new sample project (aka empty folder)
1. Inside the new folder execute `valet.sh init`
1. Set PHP version to "8.1" in the resulting `.valet-sh.yaml`
1. Execute `php -v`

*Before patch:*
The returned PHP-Version corresponds to the configured default PHP version

*After patch:*
The returned PHP version is 8.1 as configured in `.valet-sh.yaml`