### PR TITLE
Fix file synchronization when folder is not present yet

### DIFF
--- a/roles/valet-restore/tasks/workflows/magento2/main.yml
+++ b/roles/valet-restore/tasks/workflows/magento2/main.yml
@@ -83,7 +83,7 @@
     state: import
 
 - name: "workflows » magento2 | synchronize filesystem"
-  shell: "rsync -aL -e 'ssh -p {{ valet_sh_hub_port }}' {{ valet_sh_hub_user }}@{{ valet_sh_hub_host }}:{{ valet_sh_project_vars.hub.path }}/auto/fs/{{ valet_instancebackup_identifier }}/{{ valet_sh_restore_current_fs }}/ {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/" # noqa 204
+  shell: "mkdir -p {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/; rsync -aL -e 'ssh -p {{ valet_sh_hub_port }}' {{ valet_sh_hub_user }}@{{ valet_sh_hub_host }}:{{ valet_sh_project_vars.hub.path }}/auto/fs/{{ valet_instancebackup_identifier }}/{{ valet_sh_restore_current_fs }}/ {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/" # noqa 204
   with_items: "{{ valet_sh_project_vars.instance.sync.fs }}"
   when:
     - valet_sh_project_vars.instance is defined

--- a/roles/valet-restore/tasks/workflows/magento2/main.yml
+++ b/roles/valet-restore/tasks/workflows/magento2/main.yml
@@ -82,8 +82,10 @@
     encoding: "utf8"
     state: import
 
-- name: "workflows » magento2 | synchronize filesystem"
-  shell: "mkdir -p {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/; rsync -aL -e 'ssh -p {{ valet_sh_hub_port }}' {{ valet_sh_hub_user }}@{{ valet_sh_hub_host }}:{{ valet_sh_project_vars.hub.path }}/auto/fs/{{ valet_instancebackup_identifier }}/{{ valet_sh_restore_current_fs }}/ {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/" # noqa 204
+- name: "workflows » magento2 | ensure sync directories exists"
+  file:
+    path: "{{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}"
+    state: directory
   with_items: "{{ valet_sh_project_vars.instance.sync.fs }}"
   when:
     - valet_sh_project_vars.instance is defined
@@ -92,7 +94,19 @@
   loop_control:
     loop_var: valet_sh_restore_current_fs
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
+
+- name: "workflows » magento2 | synchronize filesystem"
+  shell: "rsync -aL -e 'ssh -p {{ valet_sh_hub_port }}' {{ valet_sh_hub_user }}@{{ valet_sh_hub_host }}:{{ valet_sh_project_vars.hub.path }}/auto/fs/{{ valet_instancebackup_identifier }}/{{ valet_sh_restore_current_fs }}/ {{ valet_current_path }}/{{ valet_project_src_dir }}/{{ valet_sh_restore_current_fs }}/" # noqa 204
+  with_items: "{{ valet_sh_project_vars.instance.sync.fs }}"
+  when:
+    - valet_sh_project_vars.instance is defined
+    - valet_sh_project_vars.instance.sync is defined
+    - valet_sh_project_vars.instance.sync.fs is defined
+  loop_control:
+    loop_var: valet_sh_restore_current_fs
+  tags:
+    - skip_ansible_lint
 
 - name: "workflows » magento2 | run custom sql-queries for database '{{ valet_sh_project_database_name }}'"
   mysql_query:


### PR DESCRIPTION
`TASK [valet-restore : workflows » magento2 | synchronize filesystem] ***************************************************************************************************************************************************************************************
failed: [local] (item=pub/media) => {"ansible_loop_var": "valet_sh_restore_current_fs", "changed": true, "cmd": "rsync -aL -e 'ssh -p 10122' read@xyz:/data/auto/fs/test/pub/media/ /Users/xyz/Workspace/xyz/src/pub/media/", "delta": "0:00:00.411655", "end": "2022-01-04 15:55:32.501856", "msg": "non-zero return code", "rc": 11, "start": "2022-01-04 15:55:32.090201", "stderr": "rsync: mkdir \"/Users/xyz/Workspace/xyz/project-m2/src/pub/media\" failed: No such file or directory (2)\nrsync error: error in file IO (code 11) at /System/Volumes/Data/SWE/macOS/BuildRoots/220e8a1b79/Library/Caches/com.apple.xbs/Sources/rsync/rsync-55/rsync/main.c(545) [receiver=2.6.9]", "stderr_lines": ["rsync: mkdir \"/Users/xyz/Workspace/xyz/project-m2/src/pub/media\" failed: No such file or directory (2)", "rsync error: error in file IO (code 11) at /System/Volumes/Data/SWE/macOS/BuildRoots/220e8a1b79/Library/Caches/com.apple.xbs/Sources/rsync/rsync-55/rsync/main.c(545) [receiver=2.6.9]"], "stdout": "", "stdout_lines": [], "valet_sh_restore_current_fs": "pub/media"}
`