### PR TITLE
[FIX] Adds support for Linux Mint 21 (Vanessa)

### DIFF
--- a/roles/shared-variables/tasks/main.yml
+++ b/roles/shared-variables/tasks/main.yml
@@ -58,10 +58,15 @@
   set_fact:
     os_codename: "{{ ansible_distribution_release }}"
 
-- name: "override 'os_codename' if OS is Linux Mint"
+- name: "override 'os_codename' if OS is Linux Mint 20.x"
   set_fact:
     os_codename: "focal"
   when: ansible_distribution_release == 'ulyana' or ansible_distribution_release == 'ulyssa' or ansible_distribution_release == 'uma' or ansible_distribution_release == 'una'
+
+- name: "override 'os_codename' if OS is LinuxMint 21.x"
+  set_fact:
+    os_codename: "jammy"
+  when: ansible_distribution_release == 'vanessa'
 
 - name: fail when no supported operating system was found
   fail:


### PR DESCRIPTION
As with Linux Mint 20.x we need to translate the code name of Linux Mint 21.x to its underlying Ubuntu release code name.

This PR introduces support for Linux Mint 21 (Vanessa) which is based on Ubuntu 22.04 (Jammy Jellyfish).