### PR TITLE
[FIX] Adds support for Linux Mint 21.1 (Vera) and upcoming Linux Mint 21.2 (Victoria)

### DIFF
--- a/roles/shared-variables/tasks/main.yml
+++ b/roles/shared-variables/tasks/main.yml
@@ -63,10 +63,10 @@
     os_codename: "focal"
   when: ansible_distribution_release == 'ulyana' or ansible_distribution_release == 'ulyssa' or ansible_distribution_release == 'uma' or ansible_distribution_release == 'una'
 
-- name: "override 'os_codename' if OS is LinuxMint 21.x"
+- name: "override 'os_codename' if OS is Linux Mint 21.x"
   set_fact:
     os_codename: "jammy"
-  when: ansible_distribution_release == 'vanessa'
+  when: ansible_distribution_release == 'vanessa' or ansible_distribution_release == 'vera' or ansible_distribution_release == 'victoria'
 
 - name: fail when no supported operating system was found
   fail:


### PR DESCRIPTION
Allows `valet.sh` to properly install on Linux Mint 21.1 and upcoming 21.2.
Note that the release of Linux Mint 21.2 was recently announced for June 2023. The code name might still change although it was officially announced by Linux Mint team on their blog.