### PR TITLE
Add option to use individual env template

### DIFF
--- a/roles/valet-init-instance/tasks/workflows/magento2/project-env.yml
+++ b/roles/valet-init-instance/tasks/workflows/magento2/project-env.yml
@@ -43,6 +43,7 @@
       vsh_m2_env_config_websites: "{{ valet_sh_project_vars.instance.config.system.websites | default([]) }}"
       valet_sh_magento2_db_charset: "{{ valet_sh_service_mysql_charset }}"
       valet_sh_magento2_db_collation_string: ""
+      valet_sh_project_env_template: "templates/env.php.j2"
 
   - name: "crypt_key block"
     when:
@@ -143,9 +144,16 @@
       - valet_sh_project_vars.services.rabbitmq is defined
       - valet_sh_project_vars.services.rabbitmq.vhost is defined
 
+  - name: "workflows » magento2 » project-env | detect path for env template"
+    set_fact:
+      valet_sh_project_env_template: "{{ valet_current_path }}/{{ valet_sh_project_vars.template.path }}"
+    when:
+      - valet_sh_project_vars.template is defined
+      - valet_sh_project_vars.template.path is defined
+
   - name: "workflows » magento2 » project-env | provide env.php for project"
     template:
-      src: "templates/env.php.j2"
+      src: "{{ valet_sh_project_env_template }}"
       dest: "{{ valet_sh_project_src_path }}/app/etc/env.php"
 
   when: valet_sh_project_vars.instance.processed_config is not defined

--- a/roles/valet-project/tasks/workflows/magento2/env.yml
+++ b/roles/valet-project/tasks/workflows/magento2/env.yml
@@ -43,6 +43,7 @@
       vsh_m2_env_config_websites: "{{ valet_sh_project_vars.instance.config.system.websites | default([]) }}"
       valet_sh_magento2_db_charset: "{{ valet_sh_service_mysql_charset }}"
       valet_sh_magento2_db_collation_string: ""
+      valet_sh_project_env_template: "templates/env.php.j2"
 
   - name: "crypt_key block"
     when:
@@ -143,9 +144,16 @@
       - valet_sh_project_vars.services.rabbitmq is defined
       - valet_sh_project_vars.services.rabbitmq.vhost is defined
 
+  - name: "workflows » magento2 » project-env | detect path for env template"
+    set_fact:
+      valet_sh_project_env_template: "{{ valet_current_path }}/{{ valet_sh_project_vars.template.path }}"
+    when:
+      - valet_sh_project_vars.template is defined
+      - valet_sh_project_vars.template.path is defined
+
   - name: "workflows » magento2 » project-env | provide env.php for project"
     template:
-      src: "templates/env.php.j2"
+      src: "{{ valet_sh_project_env_template }}"
       dest: "{{ valet_sh_project_src_path }}/app/etc/env.php"
 
   when: valet_sh_project_vars.instance.processed_config is not defined


### PR DESCRIPTION
Allows the usage of a project specific env.php.j2 to allow easier maintenance of project specific configuration, especially since valet.sh overwrites the env with virtually every branch change.

Usage:
1. add the following to your valet-sh.yml
```
template:
  path: "src/app/etc/env.php.j2"
```
2. Copy the env.php.j2-template from the valet.sh install directory
3. define your individual parameters like this in the valet-sh.yml
```
instance:
  backend:
    frontName: someveryrandombackendname
```
4. call the parameters in the j2-file like this
```
    'backend' => [
        'frontName' => '{{ valet_sh_project_vars.instance.backend.frontName }}'
    ],
```

