### PR TITLE
[FIX] Fixes that multidomain support could lead to strange behaviour

### DIFF
--- a/playbooks/config.yml
+++ b/playbooks/config.yml
@@ -4,7 +4,6 @@
 # @author: "Philipp Dittert"
 # @command: "config"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "Manage config parameters | Usage: valet.sh config <command> <key> <value>"
 # @usage: "valet.sh config <command> <key> <value>"
 # @help:
@@ -33,5 +32,10 @@
     valet_config_action: "{{ cli.args[0] }}"
     valet_config_key: "{{ cli.args[1] | default() }}"
     valet_config_value: "{{ cli.args[2] | default() }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-config

--- a/playbooks/exec.yml
+++ b/playbooks/exec.yml
@@ -5,7 +5,6 @@
 # @command: "exec"
 # @platform: macOS Ubuntu
 # @description: "<todo>"
-# @sudo: true
 # @usage: "valet.sh exec <action>"
 # @help:
 #
@@ -22,5 +21,10 @@
     valet_action: "{{ cli.args[0] | default() }}"
     valet_current_path: "{{ lookup('env','OLDPWD') }}"
     valet_action_target: "{{ cli.args[1] | default() }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-exec

--- a/playbooks/link.yml
+++ b/playbooks/link.yml
@@ -5,7 +5,6 @@
 # @author: "Philipp Dittert"
 # @command: "link"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "Link current directory with given name | Usage: valet.sh link projectx php72"
 # @usage: "valet.sh link <name> <php-version>"
 # @help:
@@ -28,5 +27,10 @@
     link_name: "{{ cli.args[0] | default() }}"
     valet_current_path: "{{ lookup('env','OLDPWD') }}"
     php_version: "{{ cli.args[1] | default() }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-link

--- a/playbooks/links.yml
+++ b/playbooks/links.yml
@@ -5,7 +5,6 @@
 # @author: "Philipp Dittert"
 # @command: "links"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "Show all currently linked sites"
 # @usage: "valet.sh links"
 # @help:
@@ -19,5 +18,10 @@
   gather_facts: True
   vars:
     valet_action: links
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-link

--- a/playbooks/phpstorm.yml
+++ b/playbooks/phpstorm.yml
@@ -4,7 +4,6 @@
 # @author: "Philipp Dittert"
 # @command: "phpstorm"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "starts phpstorm with current directory as argument"
 # @usage: "valet.sh phpstorm"
 # @help:
@@ -18,5 +17,10 @@
   gather_facts: True
   vars:
     valet_current_path: "{{ lookup('env','OLDPWD') }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-phpstorm

--- a/playbooks/service.yml
+++ b/playbooks/service.yml
@@ -5,7 +5,6 @@
 # @author: "Johann Zelger"
 # @command: "service"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "start/stop or enable/disable a service"
 # @usage: "valet.sh service <start|stop|restart|enable|disable|default> elasticsearch6"
 # @help:
@@ -37,5 +36,10 @@
   vars:
     valet_service_action: "{{ cli.args[0] | default() }}"
     valet_service_name: "{{ cli.args[1] | default() }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-service

--- a/playbooks/unlink.yml
+++ b/playbooks/unlink.yml
@@ -5,7 +5,6 @@
 # @author: "Philipp Dittert"
 # @command: "unlink"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "Unlink current directory with given name"
 # @usage: "valet.sh unlink <name>"
 # @help:
@@ -20,5 +19,10 @@
   vars:
     valet_action: unlink
     link_name: "{{ cli.args[0] }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-link

--- a/playbooks/update-dev-ca.yml
+++ b/playbooks/update-dev-ca.yml
@@ -5,7 +5,6 @@
 # @author: "Philipp Dittert"
 # @command: "update-dev-ca"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "adds the local development CA to Firefox/Chrome as trusted certificate"
 # @usage: "valet.sh update-dev-ca"
 # @help:
@@ -19,5 +18,10 @@
   gather_facts: True
   vars:
     update_dev_ca_force: true
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - certificate

--- a/playbooks/xdebug.yml
+++ b/playbooks/xdebug.yml
@@ -5,7 +5,6 @@
 # @author: "Philipp Dittert"
 # @command: "xdebug"
 # @platform: macOS Ubuntu
-# @sudo: true
 # @description: "enables xdebug for given php version e.g 7.2 7.3 | Usage: xdebug on 7.1"
 # @usage: "valet.sh xdebug <state> <php-version>"
 # @help:
@@ -26,5 +25,10 @@
     valet_action: "{{ cli.args[0] | default() }}"
     php_version: "{{ cli.args[1] | default() }}"
     valet_current_path: "{{ lookup('env','OLDPWD') }}"
+  vars_prompt:
+    - name: "ansible_become_pass"
+      prompt: "[sudo] Password"
+      private: yes
   roles:
+    - sudo-permission-check
     - valet-xdebug

--- a/roles/opensearch/templates/config/opensearch2.yml.j2
+++ b/roles/opensearch/templates/config/opensearch2.yml.j2
@@ -5,5 +5,5 @@ transport.port: 9322
 path.logs: "{{ opensearch_base_path }}2/logs"
 path.data: "{{ opensearch_base_path }}2/data"
 discovery.type: "single-node"
-cluster.name: opensearch1
+cluster.name: opensearch2
 plugins.security.disabled: true

--- a/roles/valet-link/templates/nginx/magento1.conf.j2
+++ b/roles/valet-link/templates/nginx/magento1.conf.j2
@@ -4,7 +4,7 @@ map $host $storecode_{{ link_name|replace("-", "_") }} {
 {% if value == "default" %}
     {{ value }} {{ key }};
 {% else %}
-    ~^{{ value }}.(.*)$ {{ key }};
+    ~^{{ value }}\.(.*)$ {{ key }};
 {% endif %}
 {% endfor %}
 }

--- a/roles/valet-link/templates/nginx/magento2.conf.j2
+++ b/roles/valet-link/templates/nginx/magento2.conf.j2
@@ -4,7 +4,7 @@ map $host $storecode_{{ link_name|replace("-", "_")  }} {
 {% if value == "default" %}
     {{ value }} {{ key }};
 {% else %}
-    ~^{{ value }}.(.*)$ {{ key }};
+    ~^{{ value }}\.(.*)$ {{ key }};
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
When a multidomain value was specified, that consists of the starting letters of the link name (e.g. value 'tr' for link name 'transfigure'), this could result in the wrong store view being shown when trying to access the default store view.
The reason was that the specified value is supposed to be a subdomain followed by a dot. In the regular expression though, the dot was not escaped and thus not literal but rather a wildcard.