### PR TITLE
replaces magic numbers for error reporting in php to the corresponding constant

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -34,7 +34,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -53,7 +53,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -88,7 +88,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -107,7 +107,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -142,7 +142,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -161,7 +161,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"#
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -192,7 +192,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -211,7 +211,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -243,7 +243,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -262,7 +262,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -294,7 +294,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -313,7 +313,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -345,7 +345,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -364,7 +364,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -396,7 +396,7 @@ php_multi:
         - conf: "memory_limit"
           value: "8192M"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_fpm_settings:
         - conf: "date.timezone"
           value: "Europe/Berlin"
@@ -415,7 +415,7 @@ php_multi:
         - conf: "sendmail_path"
           value: "{{ mailhog_bin_target }} sendmail test@test"
         - conf: "error_reporting"
-          value: "32767"
+          value: "E_ALL"
       php_modules:
         - "xmlrpc"
         - "xml"
@@ -480,7 +480,7 @@ php_cli_settings_default:
   - conf: "memory_limit"
     value: "8192M"
   - conf: "error_reporting"
-    value: "32767"
+    value: "E_ALL"
 
 
 php_cli_settings_additional_default: []
@@ -516,7 +516,7 @@ php_fpm_settings_default:
   - conf: "sendmail_path"
     value: "{{ mailhog_bin_target }} sendmail test@test"
   - conf: "error_reporting"
-    value: "32767"
+    value: "E_ALL"
 
 ## mac os specific settings
 php_fpm_settings_default_macos:
@@ -537,7 +537,7 @@ php_fpm_settings_default_macos:
   - conf: "sendmail_path"
     value: "{{ mailhog_bin_target }} sendmail test@test"
   - conf: "error_reporting"
-    value: "32767"
+    value: "E_ALL"
 
 php_fpm_settings_additional_default: []
 


### PR DESCRIPTION
With PHP 8.4 the value for the error reporting constant "E_ALL" changed from 32767 to 30719.

The magic number is set as default value for error_reporting in 95-valet-sh.ini. This leads to a faulty error reporting code in php8.4 environments. 

Using the constant E_ALL for all versions should mitigate that issue for all available versions.